### PR TITLE
Criação v1 Dimensão Clientes

### DIFF
--- a/models/intermediate/int_clients__enriched.sql
+++ b/models/intermediate/int_clients__enriched.sql
@@ -1,0 +1,56 @@
+with
+    customers as (
+        select customer_pk, person_fk, store_fk
+        from {{ ref('stg_erp__customers') }}
+    )
+    , persons as (
+        select b_e_persons_pk, person_firstname, person_lastname, person_middlename, person_type
+        from {{ ref('stg_erp__persons') }}
+    )
+    , stores as (
+        select b_e_stores_pk, store_name
+        from {{ ref('stg_erp__stores') }}
+    )
+    , person_type as (
+        select *
+        from {{ ref('de_para_person_type') }}
+    )
+    , joined as (
+        select 
+        c.customer_pk
+        , c.store_fk
+        , c.person_fk
+        -- businessentityid: usa store_fk se tiver, senão person_fk
+        --, coalesce(c.store_fk, c.person_fk) as businessentityid
+        -- nome da pessoa
+        , case 
+            when p.person_firstname is not null and p.person_lastname is not null then 
+                p.person_firstname || 
+                case when p.person_middlename is not null then ' ' || p.person_middlename else '' end || 
+                ' ' || p.person_lastname
+            when p.person_firstname is not null then p.person_firstname
+            else null
+        end as person_name
+        , pt.tipo as person_type        
+        -- nome da loja
+        , s.store_name
+        -- nome do cliente
+        , case 
+            when p.person_type = 'SC' then s.store_name
+            else person_name
+        end as customer_name
+        ---- tipo do cliente
+        , case
+            when p.person_type = 'SC' then 'Stores'
+            else 'Direct Sales'
+        end as customer_type
+        from customers c
+        left join persons p on p.b_e_persons_pk = c.person_fk
+        left join stores s on s.b_e_stores_pk = c.store_fk
+        left join person_type pt on p.person_type = pt.Codigo
+    )
+    select *
+    from joined
+    where trim(person_type) = 'Store Contact' or trim(person_type) = 'Individual'
+    
+

--- a/models/marts/dim_clients.sql
+++ b/models/marts/dim_clients.sql
@@ -1,0 +1,9 @@
+with
+
+    int_clients as (
+        select *
+        from {{ ref('int_clients__enriched') }}
+    )
+
+select *
+from int_clients

--- a/models/marts/dim_clients.yml
+++ b/models/marts/dim_clients.yml
@@ -1,0 +1,30 @@
+models:
+  - name: dim_clients
+    description: Dimension model with customer and related entity information.
+    columns:
+      - name: customer_pk
+        description: Primary key identifying the customer.
+        tests:
+          - unique
+          - not_null
+
+      - name: store_fk
+        description: Foreign key referencing the store, if applicable.
+
+      - name: person_fk
+        description: Foreign key referencing the person, if applicable.
+
+      - name: person_name
+        description: Full name of the person, concatenating first, middle (if any), and last name.
+
+      - name: person_type
+        description: Type of person (e.g., individual, store contact).
+
+      - name: store_name
+        description: Name of the store associated with the customer.
+
+      - name: customer_name
+        description: Name used for the customer; store name if person type is 'SC' (Store Contact), otherwise person name.
+
+      - name: customer_type
+        description: Type of customer, either 'Stores' or 'Direct Sales' based on person_type.

--- a/models/staging/erp/stg_erp__customers.sql
+++ b/models/staging/erp/stg_erp__customers.sql
@@ -1,0 +1,24 @@
+with 
+
+source as (
+
+    select * 
+    from {{ source('erp', 'sales_customer') }}
+
+),
+
+renamed as (
+
+    select
+        cast(customerid as int) as customer_pk
+        , cast(personid as int) as person_fk
+        , cast(storeid as int) as store_fk
+        , cast(territoryid as int) as territory_fk
+        --rowguid,
+        --modifieddate
+
+    from source
+
+)
+
+select * from renamed

--- a/models/staging/erp/stg_erp__persons.sql
+++ b/models/staging/erp/stg_erp__persons.sql
@@ -1,0 +1,31 @@
+with 
+
+source as (
+
+    select * 
+    from {{ source('erp', 'person_person') }}
+
+)
+
+, renamed as (
+
+    select
+        cast(businessentityid as int) as b_e_persons_pk
+        , persontype as person_type
+        --, namestyle as person_name
+        , title as person_title
+        , firstname as person_firstname
+        , middlename as person_middlename
+        , lastname as person_lastname
+        --, suffix as 
+        --, emailpromotion as 
+        --, additionalcontactinfo as 
+        --, demographics as 
+        --, rowguid as 
+        --, modifieddat as 
+
+    from source
+
+)
+
+select * from renamed

--- a/models/staging/erp/stg_erp__stores.sql
+++ b/models/staging/erp/stg_erp__stores.sql
@@ -1,0 +1,24 @@
+with 
+
+source as (
+
+    select * 
+    from {{ source('erp', 'sales_store') }}
+
+)
+
+, renamed as (
+
+    select
+        cast(businessentityid as int) as b_e_stores_pk
+        , cast(salespersonid as int) as salesperson_fk
+        , name as store_name
+        --demographics,
+        --rowguid,
+        --modifieddate
+
+    from source
+
+)
+
+select * from renamed

--- a/seeds/de_para_person_type.csv
+++ b/seeds/de_para_person_type.csv
@@ -1,0 +1,7 @@
+Codigo,tipo,Descricao
+SC,Store Contact,Contato de uma loja (empresa cliente)
+IN,Individual,Pessoa física (cliente individual)
+SP,Sales Person,Vendedor
+EM,Employee,Funcionário (não necessariamente vendedor)
+VC,Vendor Contact,Contato de fornecedor
+GC,General Contact,Outro tipo de contato


### PR DESCRIPTION
Por quê?
Para disponibilizar a dimensão de clientes, consolidando dados de customers, persons e stores com enriquecimento adicional via seed de tipo de pessoa. Isso permite análises mais completas e categorizadas por tipo de cliente.

O que está mudando?

Criação do modelo dim_clients.sql em models/marts/
Criação do modelo intermediário int_clients__enriched.sql em models/intermediate/
Criação dos modelos de staging em models/staging/erp/:
     stg_erp__customers.sql
     stg_erp__persons.sql
     stg_erp__stores.sql
Criação da seed de_para_person_type.csv em seeds/
Adição do arquivo de documentação dim_clients.yml com descrição e testes das colunas

-- Checklist
Todos os modelos rodam com sucesso? Sim
Modelo mart tem documentação? Sim