### PR TITLE
Criada v1 Dimensão Localizações

### DIFF
--- a/models/intermediate/int_locations__enriched.sql
+++ b/models/intermediate/int_locations__enriched.sql
@@ -1,0 +1,35 @@
+with
+    -- importing models
+    addresses as(
+        select *
+        from {{ ref('stg_erp__persons_addresses') }}
+    )
+    , countriregions as(
+        select *
+        from {{ ref('stg_erp__persons_countryregions') }}
+    )
+    , stateprovinces as(
+        select *
+        from {{ ref('stg_erp__persons_stateprovinces') }}
+    )
+    , territories as(
+        select *
+        from {{ ref('stg_erp__territories') }}
+    )
+    , joined as (
+        select
+            address_pk
+            , address_city
+            , state_province_code_fk as stateprovince_code
+            , state_province_name
+            , territory_name
+            , country_code
+            , country_region_name as country_name
+            , continent
+        from addresses
+        left join stateprovinces on stateprovinces.stateprovince_pk = addresses.stateprovince_fk        
+        left join territories on territories.territory_pk = stateprovinces.territory_fk
+        left join countriregions on stateprovinces.country_region_code_fk = countriregions.country_region_code_pk
+    )
+    select *
+    from joined

--- a/models/marts/dim_locations.sql
+++ b/models/marts/dim_locations.sql
@@ -1,0 +1,9 @@
+with
+
+    int_locations as (
+        select *
+        from {{ ref('int_locations__enriched') }}
+    )
+
+select *
+from int_locations

--- a/models/marts/dim_locations.yml
+++ b/models/marts/dim_locations.yml
@@ -1,0 +1,30 @@
+models:
+  - name: dim_locations
+    description: Dimension model containing location information including address, state, territory, country, and continent.
+    columns:
+      - name: address_pk
+        description: Primary key identifying the address record.
+        tests:
+          - unique
+          - not_null
+
+      - name: address_city
+        description: City of the address.
+
+      - name: stateprovince_code
+        description: Foreign key referencing the state or province code.
+
+      - name: state_province_name
+        description: Name of the state or province.
+
+      - name: territory_name
+        description: Name of the sales territory or region.
+
+      - name: country_code
+        description: Code of the country for the address.
+
+      - name: country_name
+        description: Name of the country (alias for country_region_name).
+
+      - name: continent
+        description: Continent where the address is located.

--- a/models/staging/erp/stg_erp__persons_addresses.sql
+++ b/models/staging/erp/stg_erp__persons_addresses.sql
@@ -1,0 +1,27 @@
+with 
+
+source as (
+
+    select * 
+    from {{ source('erp', 'person_address') }}
+
+)
+
+, renamed as (
+
+    select
+        cast(addressid as int) as address_pk
+        , cast(stateprovinceid as int) as stateprovince_fk
+        --, addressline1
+        --, addressline2
+        , city as address_city
+        --, postalcode
+        --, spatiallocation
+        --, rowguid
+        --, modifieddat
+
+    from source
+
+)
+
+select * from renamed

--- a/models/staging/erp/stg_erp__persons_countryregions.sql
+++ b/models/staging/erp/stg_erp__persons_countryregions.sql
@@ -1,0 +1,21 @@
+with 
+
+source as (
+
+    select * 
+    from {{ source('erp', 'person_countryregion') }}
+
+)
+
+, renamed as (
+
+    select
+        countryregioncode as country_region_code_pk
+        , name as country_region_name
+        --modifieddate
+
+    from source
+
+)
+
+select * from renamed

--- a/models/staging/erp/stg_erp__persons_stateprovinces.sql
+++ b/models/staging/erp/stg_erp__persons_stateprovinces.sql
@@ -1,0 +1,26 @@
+with 
+
+source as (
+
+    select * 
+    from {{ source('erp', 'person_stateprovince') }}
+
+)
+
+, renamed as (
+
+    select
+        cast(stateprovinceid as int) as stateprovince_pk
+        , cast(territoryid as int) as territory_fk
+        , stateprovincecode as state_province_code_fk
+        , countryregioncode as country_region_code_fk
+        --, isonlystateprovinceflag
+        , name as state_province_name
+        --rowguid,
+        --modifieddate
+
+    from source
+
+)
+
+select * from renamed

--- a/models/staging/erp/stg_erp__territories.sql
+++ b/models/staging/erp/stg_erp__territories.sql
@@ -1,0 +1,27 @@
+with 
+
+source as (
+
+    select * from {{ source('erp', 'sales_salesterritory') }}
+
+),
+
+renamed as (
+
+    select
+        cast(territoryid as int) as territory_pk
+        , name as territory_name
+        , countryregioncode as country_code
+        , "group" as continent
+        , cast(salesytd as numeric(18,4)) as territory_salesytd
+        , cast(saleslastyear as numeric(18,4)) as territory_salesly
+        --, cast(costytd as numeric(18,4))
+        --, cast(costlastyear as numeric(18,4))
+        --, rowguid
+        --, modifieddat
+
+    from source
+
+)
+
+select * from renamed


### PR DESCRIPTION
Por quê?

Para disponibilizar a dimensão de localizações, unificando dados geográficos (endereços, estados, regiões e países) com base nas entidades do ERP. Essa dimensão facilita análises por localização em diversos níveis hierárquicos.

O que está mudando?

Criação do modelo dim_locations.sql em models/marts/
Criação do modelo intermediário int_locations__enriched.sql em models/intermediate/
Criação dos modelos de staging em models/staging/erp/:
     stg_erp__persons_addresses.sql
     stg_erp__persons_countryregions.sql
     stg_erp__persons_stateprovinces.sql
     stg_erp__territories.sql

Adição do arquivo de documentação dim_locations.yml com descrição e testes das colunas

-- Checklist
Todos os modelos rodam com sucesso? Sim
Modelo mart tem documentação? Sim