### PR TITLE
Criação v1 dimensão razões para vendas

### DIFF
--- a/models/intermediate/int__salesreason.sql
+++ b/models/intermediate/int__salesreason.sql
@@ -1,0 +1,9 @@
+with
+
+    salesreasons as (
+        select *
+        from {{ ref('stg_erp__sales_reason') }}
+    )
+
+select *
+from salesreasons

--- a/models/marts/dim_salesreasons.sql
+++ b/models/marts/dim_salesreasons.sql
@@ -1,0 +1,9 @@
+with
+
+    int_salesreasons as (
+        select *
+        from {{ ref('int__salesreason') }}
+    )
+
+select *
+from int_salesreasons

--- a/models/marts/dim_salesreasons.yml
+++ b/models/marts/dim_salesreasons.yml
@@ -1,0 +1,15 @@
+models:
+  - name: dim_salesreasons
+    description: Dimension model containing reasons associated with sales orders.
+    columns:
+      - name: sales_reason_pk
+        description: Primary key identifying the sales reason (cast from salesreasonid).
+        tests:
+          - unique
+          - not_null
+
+      - name: reason_name
+        description: Name or description of the sales reason.
+
+      - name: reason_type
+        description: Category or type of the sales reason.

--- a/models/staging/erp/stg_erp__sales_reason.sql
+++ b/models/staging/erp/stg_erp__sales_reason.sql
@@ -1,0 +1,22 @@
+with 
+
+source as (
+
+    select * 
+    from {{ source('erp', 'sales_salesreason') }}
+
+)
+
+, renamed as (
+
+    select
+        cast(salesreasonid as int) as sales_reason_pk
+        , name as reason_name
+        , reasontype as reason_type
+        -- , modifieddat
+
+    from source
+
+)
+
+select * from renamed


### PR DESCRIPTION
Por quê?

Para disponibilizar a dimensão de razões para vendas, permitindo categorizar e analisar os motivos associados a pedidos de venda, como promoções, campanhas ou recomendações.

O que está mudando?

Criação do modelo dim_salesreasons.sql em models/marts/
Criação do modelo intermediário int__salesreasons.sql em models/intermediate/
Criação do modelo de staging stg_erp__sales_reason.sql em models/staging/erp/
Adição do arquivo de documentação dim_salesreasons.yml com descrição e testes das colunas

-- Checklist
Todos os modelos rodam com sucesso? Sim
Modelo mart tem documentação? Sim