### PR TITLE
Criação v1 tabela fato vendas

### DIFF
--- a/models/intermediate/int_sales_metrics.sql
+++ b/models/intermediate/int_sales_metrics.sql
@@ -1,0 +1,81 @@
+with
+    -- importing models
+    orders_details as(
+        select *
+        from {{ ref('stg_erp__orders_details') }}
+    )
+    , orders as(
+        select *
+        from {{ ref('stg_erp__orders') }}
+    )
+    , creditcards as(
+        select *
+        from {{ ref('stg_erp__creditcards') }}
+    )
+-- transformation
+    , joined as (
+        select
+            --orders_details.order_detail_pk
+            {{ dbt_utils.generate_surrogate_key(['order_detail_pk', 'order_pk']) }} as order_item_sk
+            , orders.order_pk as order_fk
+            , orders_details.product_fk
+            , orders_details.special_offer_fk
+            , orders.customer_fk
+            , orders.salesperson_fk
+            , orders.territory_fk
+            , orders.creditcard_fk       
+            , orders_details.order_quantity
+            , orders_details.order_unit_price
+            , orders_details.order_price_discount
+            , orders.order_date
+            , orders.order_subtotal
+            , orders.order_tax_amount
+            , orders.order_freight
+            , orders.order_totaldue
+            , orders.shiptoaddress_fk
+            , orders.billtoaddress_fk
+            , orders.status
+            , creditcards.cardtype
+        from orders_details
+        left join orders on orders_details.order_fk = orders.order_pk
+        left join creditcards on orders.creditcard_fk = creditcards.creditcard_pk
+    )
+    , metrics as (
+        select
+            order_item_sk
+            , order_fk
+            , product_fk
+            , special_offer_fk
+            , customer_fk
+            --, person_fk
+            --, store_fk
+            , salesperson_fk
+            , territory_fk
+            --, creditcard_fk
+            , shiptoaddress_fk
+            , billtoaddress_fk
+            , order_date
+            , status
+            , case
+                when cardtype is null then 'Payment without credit card'
+                else cardtype
+            end as cardtype       
+            , order_quantity as qty
+            , cast(order_unit_price as numeric(18,4)) as unit_price
+            , cast((order_unit_price * order_quantity) as numeric(18,4)) as total_gross
+            , cast(order_price_discount as numeric(18,2)) as discount
+            , order_unit_price * (1 - order_price_discount) * 
+                order_quantity as subtotal
+            , cast((subtotal * order_freight / sum(subtotal) over (partition by order_fk)) 
+                as numeric(18,4)) as freight_allocated
+            , cast((subtotal * order_tax_amount / sum(subtotal) over (partition by order_fk)) 
+                as numeric(18,4)) as tax_allocated
+            , subtotal + freight_allocated + tax_allocated as total_due
+            --, order_subtotal
+            --, order_tax_amount
+            --, order_freight
+            --, order_totaldue
+        from joined
+    )
+select * 
+from metrics

--- a/models/marts/fct_sales.sql
+++ b/models/marts/fct_sales.sql
@@ -1,0 +1,9 @@
+with
+
+    fct_sales as (
+        select *
+        from {{ ref('int_sales_metrics') }}
+    )
+
+select *
+from fct_sales

--- a/models/marts/fct_sales.yml
+++ b/models/marts/fct_sales.yml
@@ -1,0 +1,66 @@
+models:
+  - name: fct_sales
+    description: Fact model with sales data and metrics.
+    columns:
+      - name: order_item_sk
+        description: Surrogate primary key generated from order_detail_pk and order_pk.
+        tests:
+          - unique
+          - not_null
+
+      - name: order_fk
+        description: Foreign key referencing the sales order.
+
+      - name: product_fk
+        description: Foreign key referencing the product.
+
+      - name: special_offer_fk
+        description: Foreign key referencing the special offer applied to the order.
+
+      - name: customer_fk
+        description: Foreign key referencing the customer who placed the order.
+
+      - name: salesperson_fk
+        description: Foreign key referencing the salesperson responsible for the order.
+
+      - name: territory_fk
+        description: Foreign key referencing the sales territory.
+
+      - name: shiptoaddress_fk
+        description: Foreign key referencing the shipping address.
+
+      - name: billtoaddress_fk
+        description: Foreign key referencing the billing address.
+
+      - name: order_date
+        description: Date when the order was placed.
+
+      - name: status
+        description: Current status of the order.
+
+      - name: cardtype
+        description: Type of credit card used for payment or indication of no credit card.
+
+      - name: qty
+        description: Quantity of product ordered.
+
+      - name: unit_price
+        description: Unit price of the product ordered..
+
+      - name: total_gross
+        description: Total gross amount before discount (unit price * quantity).
+
+      - name: discount
+        description: Discount applied on the order.
+
+      - name: subtotal
+        description: Subtotal amount after discount (unit price * (1 - discount) * quantity).
+
+      - name: freight_allocated
+        description: Freight cost allocated to the order item proportionally.
+
+      - name: tax_allocated
+        description: Tax cost allocated to the order item proportionally.
+
+      - name: total_due
+        description: Total amount due for the order item (subtotal + freight_allocated + tax_allocated).

--- a/models/staging/erp/stg_erp__creditcards.sql
+++ b/models/staging/erp/stg_erp__creditcards.sql
@@ -1,0 +1,24 @@
+with 
+
+source as (
+
+    select * 
+    from {{ source('erp', 'sales_creditcard') }}
+
+)
+
+, renamed as (
+
+    select
+        cast(creditcardid as int) as creditcard_pk,
+        cardtype,
+        --cardnumber,
+        --expmonth,
+        --expyear,
+        --modifieddate
+
+    from source
+
+)
+
+select * from renamed

--- a/models/staging/erp/stg_erp__orders.sql
+++ b/models/staging/erp/stg_erp__orders.sql
@@ -1,0 +1,52 @@
+with 
+
+source as (
+
+    select * 
+    from {{ source('erp', 'sales_salesorderheader') }}
+
+)
+
+, status_map as (
+
+    select * 
+    from {{ ref('status_de_para') }}
+
+)
+
+, renamed as (
+
+    select
+        cast(salesorderid as int) as order_pk
+        , cast(orderdate as date) as order_date
+        , cast(customerid as int) as customer_fk
+        , cast(salespersonid as int) as salesperson_fk
+        , cast(territoryid as int) as territory_fk
+        , cast(creditcardid as int) as creditcard_fk
+        , cast(subtotal as numeric(18,4)) as order_subtotal
+        , cast(taxamt as numeric(18,4)) as order_tax_amount
+        , cast(freight as numeric(18,4)) as order_freight
+        , cast(totaldue as numeric(18,4)) as order_totaldue
+        , cast(billtoaddressid as int) as billtoaddress_fk
+        , cast(shiptoaddressid as int) as shiptoaddress_fk
+        , sm.titulo as status
+        --, revisionnumber      
+        --, duedate
+        --, shipdate      
+        --, onlineorderfla,
+        --, purchaseordernmber,
+        --, accountnumber,               
+        --, shipmethodid,       
+        --, creditcardapprvalcode,
+        --, currencyrateid
+        --, comment
+        --, rowguid
+        --, modifieddat
+
+    from source so
+    left join status_map sm
+        on cast(so.status as integer) = sm.codigo
+
+)
+
+select * from renamed

--- a/models/staging/erp/stg_erp__orders_details.sql
+++ b/models/staging/erp/stg_erp__orders_details.sql
@@ -1,0 +1,28 @@
+with 
+
+source as (
+
+    select * 
+    from {{ source('erp', 'sales_salesorderdetail') }}
+
+)
+
+, renamed as (
+
+    select
+        cast(salesorderid as int) as order_fk
+        , cast(salesorderdetailid as int) as order_detail_pk
+        , cast(orderqty as int) as order_quantity
+        , cast(productid as int) as product_fk
+        , cast(specialofferid as int) as special_offer_fk
+        , cast(unitprice as numeric(18,4)) as order_unit_price
+        , cast(unitpricediscount as numeric(18,2)) as order_price_discount
+        --carriertrackingnumber,
+        --rowguid,
+        --modifieddate
+
+    from source
+
+)
+
+select * from renamed

--- a/package-lock.yml
+++ b/package-lock.yml
@@ -1,0 +1,5 @@
+packages:
+  - name: dbt_utils
+    package: dbt-labs/dbt_utils
+    version: 1.3.0
+sha1_hash: 226ae69cdfbc9367e2aa2c472b01f99dbce11de0

--- a/packages.yml
+++ b/packages.yml
@@ -1,0 +1,3 @@
+packages:
+  - package: dbt-labs/dbt_utils
+    version: 1.3.0

--- a/seeds/status_de_para.csv
+++ b/seeds/status_de_para.csv
@@ -1,0 +1,7 @@
+codigo,titulo
+1,In process
+2,Approved
+3,Backordered
+4,Rejected
+5,Shipped
+6,Cancelled


### PR DESCRIPTION
Por quê?

Para consolidar os dados transacionais de vendas em uma tabela fato (fct_sales), permitindo análises quantitativas como volume de pedidos, valor total de vendas e formas de pagamento, com base em pedidos e seus detalhes.

O que está mudando?

Criação da fato fct_sales.sql em models/marts/
Criação do modelo intermediário int_sales_metrics.sql em models/intermediate/
Criação dos modelos de staging em models/staging/erp/:
     stg_erp__orders.sql
     stg_erp__orders_details.sql
     stg_erp__creditcards.sql

Adição do arquivo de documentação fct_sales.yml com descrição e testes das colunas
Adição da seed status_de_para.csv para padronização de status dos pedidos
Inclusão do pacote dbt_utils (version: 1.3.0) nos arquivos packages.yml e package-lock.yml

Checklist
Todos os modelos rodam com sucesso? Sim
Fato de vendas tem documentação? Sim
Pacotes atualizados e versionados? Sim