### PR TITLE
Criação v1 tabela fato ponte entre fct_sales e dim_salesreasons

### DIFF
--- a/models/intermediate/int_bridge_salesreasons.sql
+++ b/models/intermediate/int_bridge_salesreasons.sql
@@ -1,0 +1,13 @@
+with
+
+    bridge_reasons as (
+        select 
+            --orders_details.order_detail_pk
+            {{ dbt_utils.generate_surrogate_key(['sales_order_pk', 'sales_reason_fk']) }} as bridge_reasons_sk
+            , sales_order_pk
+            , sales_reason_fk
+        from {{ ref('stg_erp__sales_order_header_reasons') }}
+    )
+
+select *
+from bridge_reasons

--- a/models/marts/fct_bridge_salesreasons.sql
+++ b/models/marts/fct_bridge_salesreasons.sql
@@ -1,0 +1,9 @@
+with
+
+    int_bridge_reasons as (
+        select *
+        from {{ ref('int_bridge_salesreasons') }}
+    )
+
+select *
+from int_bridge_reasons

--- a/models/marts/fct_bridge_salesreasons.yml
+++ b/models/marts/fct_bridge_salesreasons.yml
@@ -1,0 +1,15 @@
+models:
+  - name: fct_bridge_salesreasons
+    description: Bridge table modeling the many-to-many relationship between sales orders and sales reasons.
+    columns:
+      - name: bridge_reasons_sk
+        description: Surrogate primary key generated from sales_order_pk and sales_reason_fk.
+        tests:
+          - unique
+          - not_null
+
+      - name: sales_order_pk
+        description: Foreign key referencing the sales order.
+
+      - name: sales_reason_fk
+        description: Foreign key referencing the sales reason.

--- a/models/staging/erp/stg_erp__sales_order_header_reasons.sql
+++ b/models/staging/erp/stg_erp__sales_order_header_reasons.sql
@@ -1,0 +1,21 @@
+with 
+
+source as (
+
+    select * 
+    from {{ source('erp', 'sales_salesorderheadersalesreason') }}
+
+)
+
+, renamed as (
+
+    select
+        cast(salesorderid as int) as sales_order_pk
+        , cast(salesreasonid as int) as sales_reason_fk
+        --, modifieddate
+
+    from source
+
+)
+
+select * from renamed


### PR DESCRIPTION
Por quê?

Para modelar corretamente a relação muitos-para-muitos entre os pedidos e os motivos de venda, foi criada a tabela fato ponte fct_bridge_salesreasons. Isso permite análises combinadas de vendas e seus motivos, garantindo granularidade adequada na modelagem dimensional.

O que está mudando?
Criação da fato ponte fct_bridge_salesreasons.sql em models/marts/
Criação do modelo intermediário int_bridge_salesreasons.sql em models/intermediate/
Criação do modelo de staging stg_erp__sales_order_header_reasons.sql em models/staging/erp/
Adição do arquivo fct_bridge_salesreasons.yml com descrição e testes de integridade (chave única e not null)

Checklist
Modelo de fato ponte criado com integridade referencial? Sim
Documentação adicionada com testes? Sim
Models de staging e intermediate implementados? Sim
Execução completa sem erros? Sim