### PR TITLE
Criação v1 dimensão status

### DIFF
--- a/models/intermediate/int__status.sql
+++ b/models/intermediate/int__status.sql
@@ -1,0 +1,11 @@
+with
+
+    seed_status as (
+        select
+            codigo as status_pk
+            , titulo as status_name
+        from {{ ref('status_de_para') }}
+    )
+
+select *
+from seed_status

--- a/models/intermediate/int_sales_metrics.sql
+++ b/models/intermediate/int_sales_metrics.sql
@@ -12,12 +12,7 @@ with
         select *
         from {{ ref('stg_erp__creditcards') }}
     )
-    , status_map as (
 
-        select * 
-        from {{ ref('status_de_para') }}
-
-    )
 -- transformation
     , joined as (
         select
@@ -40,13 +35,11 @@ with
             , orders.order_totaldue
             , orders.shiptoaddress_fk
             , orders.billtoaddress_fk
-            , orders.status
-            , sm.titulo
+            , orders.status_fk
             , creditcards.cardtype
         from orders_details
         left join orders on orders_details.order_fk = orders.order_pk
         left join creditcards on orders.creditcard_fk = creditcards.creditcard_pk
-        left join status_map sm on orders.status = sm.codigo
     )
     , metrics as (
         select
@@ -62,8 +55,8 @@ with
             --, creditcard_fk
             , shiptoaddress_fk
             , billtoaddress_fk
+            , status_fk
             , order_date
-            , titulo as status
             , case
                 when cardtype is null then 'Payment without credit card'
                 else cardtype

--- a/models/marts/dim_status.sql
+++ b/models/marts/dim_status.sql
@@ -1,0 +1,9 @@
+with
+
+    int_status as (
+        select *
+        from {{ ref('int__status') }}
+    )
+
+select *
+from int_status

--- a/models/marts/dim_status.yml
+++ b/models/marts/dim_status.yml
@@ -1,0 +1,12 @@
+models:
+  - name: dim_status
+    description: Dimension model containing the status of the orders.
+    columns:
+      - name: status_pk
+        description: Primary key identifying the status.
+        tests:
+          - unique
+          - not_null
+
+      - name: status_name
+        description: Name of the status.

--- a/models/staging/erp/stg_erp__orders.sql
+++ b/models/staging/erp/stg_erp__orders.sql
@@ -16,13 +16,13 @@ source as (
         , cast(salespersonid as int) as salesperson_fk
         , cast(territoryid as int) as territory_fk
         , cast(creditcardid as int) as creditcard_fk
+        , cast(billtoaddressid as int) as billtoaddress_fk
+        , cast(shiptoaddressid as int) as shiptoaddress_fk
+        , cast(status as int) as status_fk
         , cast(subtotal as numeric(18,4)) as order_subtotal
         , cast(taxamt as numeric(18,4)) as order_tax_amount
         , cast(freight as numeric(18,4)) as order_freight
         , cast(totaldue as numeric(18,4)) as order_totaldue
-        , cast(billtoaddressid as int) as billtoaddress_fk
-        , cast(shiptoaddressid as int) as shiptoaddress_fk
-        , cast(status as int) as status
         --, revisionnumber      
         --, duedate
         --, shipdate      


### PR DESCRIPTION
-- Por quê?
Para garantir a modelagem em estrela e normalizar os dados de status dos pedidos, foi criada a dimensão dim_status. Isso permite melhor rastreabilidade, performance e reutilização dos atributos de status em múltiplas tabelas fato.

O que está mudando?

Criação da dimensão dim_status.sql em models/marts/
Criação do modelo intermediário int_status.sql em models/intermediate/ com base na seed status_de_para.csv
Adição do arquivo dim_status.yml com descrição e testes de integridade (chave única e not null)
Atualização da fato fct_sales.sql para utilizar a status_fk ao invés do campo de status textual

-- Checklist
Dimensão dim_status criada com integridade referencial? Sim
Documentação adicionada com testes? Sim
Models  intermediate implementados? Sim
Atualização na fato fct_sales refletindo a foreign key? Sim
Execução completa sem erros? Sim